### PR TITLE
Added scripts so that we can have a dialogue manager (GameObject with…

### DIFF
--- a/Assets/Scripts/Character/PlayerInput.cs
+++ b/Assets/Scripts/Character/PlayerInput.cs
@@ -10,6 +10,7 @@ public class PlayerInput : BaseInput {
   [SerializeField] private CameraBob cameraBob;
   [SerializeField] private CameraShader futureShader;
   [SerializeField] private AudioSource interactionAudio;
+  [SerializeField] private DialogueManager dialogueManager;
 
   public static ControlActions Controls;
   private bool activeMovementInput = false;
@@ -55,6 +56,10 @@ public class PlayerInput : BaseInput {
       var cameraTransform = Camera.main.transform;
       Interactable.GiveClosestInteractableInViewOutline(cameraTransform.position, cameraTransform.forward, itemHolder);
     //}
+
+    if (Input.anyKeyDown){
+        dialogueManager.NextSentence();
+    }
 
   }
 

--- a/Assets/Scripts/Character/PlayerInput.cs
+++ b/Assets/Scripts/Character/PlayerInput.cs
@@ -57,7 +57,7 @@ public class PlayerInput : BaseInput {
       Interactable.GiveClosestInteractableInViewOutline(cameraTransform.position, cameraTransform.forward, itemHolder);
     //}
 
-    if (Input.anyKeyDown){
+    if (dialogueManager && Input.anyKeyDown){
         dialogueManager.NextSentence();
     }
 

--- a/Assets/Scripts/UI/Dialogue.meta
+++ b/Assets/Scripts/UI/Dialogue.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7f845fd5705dd6498a15bc30648dd2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Dialogue/Dialogue.cs
+++ b/Assets/Scripts/UI/Dialogue/Dialogue.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class Dialogue
+{
+    private string label;
+    [TextArea(3,10)] public string[] sentences;
+}

--- a/Assets/Scripts/UI/Dialogue/Dialogue.cs.meta
+++ b/Assets/Scripts/UI/Dialogue/Dialogue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ccc71a7cad6da684e9639f600cdb23ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/UI/Dialogue/DialogueManager.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class DialogueManager : MonoBehaviour
+{
+    private Queue<string> sentences;
+    [SerializeField] private TextMesh field;
+    public bool isDialoging = false;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        sentences = new Queue<string>();
+    }
+
+    public void StartDialogue(Dialogue dialogue)
+    {
+        isDialoging = true;
+        Debug.Log("Just starting...");
+        sentences.Clear();
+
+        foreach (string sentence in dialogue.sentences) {
+            sentences.Enqueue(sentence);
+        }
+
+        NextSentence();
+    }
+
+    public void NextSentence() {
+        if (sentences.Count == 0) {
+            EndDialogue();
+        }
+        
+        if (!isDialoging) {
+            Debug.Log("yeedogeee");
+            return;
+        }
+        
+        string sentence = sentences.Dequeue();
+        StopAllCoroutines();
+        StartCoroutine(DisplaySentence(sentence));
+    }
+
+    IEnumerator DisplaySentence(string sentence) {
+        field.text = "";
+        foreach (char letter in sentence.ToCharArray())
+        {
+            field.text += letter;
+            yield return null;
+        }
+    }
+
+    private void EndDialogue()
+    {
+        isDialoging = false;
+        field.text = "";
+        sentences.Clear();
+        Debug.Log("end...");
+    }
+
+}

--- a/Assets/Scripts/UI/Dialogue/DialogueManager.cs.meta
+++ b/Assets/Scripts/UI/Dialogue/DialogueManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f78ae4e7f147c8544bc30d6231c7d0c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Dialogue/DialogueTrigger.cs
+++ b/Assets/Scripts/UI/Dialogue/DialogueTrigger.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DialogueTrigger : MonoBehaviour
+{
+    public Dialogue dialogue; 
+    [SerializeField] private DialogueManager manager;
+
+    void Start() {
+        if (!manager) {
+            manager = FindObjectOfType<DialogueManager>();
+        }
+    }
+
+    public void TriggerDialogue() {
+        manager.StartDialogue(dialogue);
+    }
+    
+}

--- a/Assets/Scripts/UI/Dialogue/DialogueTrigger.cs.meta
+++ b/Assets/Scripts/UI/Dialogue/DialogueTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca3291ec465c79c49ac3d8947cc6d916
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Tried added a system to print out dialogue that's general enough that we can apply it to multiple instances of when we want text to be printed out to the screen for narrative

## Changes:
- Added DialogueManager class
- Added Dialogue class
- Added Dialogue Trigger class

## Comments:
- You attach the DialogueManager class to the gameobject that has access to the field which we want our text to go
- You attach the DialogueTrigger class to whatever is going to trigger the text to be outputed 


### How to Test:
Atm difficult to test as I didnt attach my test gameobjects. But quickly making a text field (attach it to dialoguemanager) and a button (trigger) should be enough to get you started with testing.

### Sample Test Cases:
Start dialogue 

### Impacted Features:
- UI
- Future dialogue for NPCs


