### PR TITLE
Synchronize Future Transition

### DIFF
--- a/Assets/Prefabs/FutureHero.prefab
+++ b/Assets/Prefabs/FutureHero.prefab
@@ -1484,16 +1484,15 @@ MonoBehaviour:
   _bodyCollider: {fileID: 2827159014478899484}
   _groundLayer:
     serializedVersion: 2
-    m_Bits: 256
+    m_Bits: 512
   _watchArmAnimation: {fileID: 7472229314023975396}
   pitchDegree: 0
   yawDegree: 0
   velocity: {x: 0, y: 0, z: 0}
   moveDirection: {x: 0, y: 0, z: 0}
-  sensitivity: 1
-  sprintMultiplier: 1
-  groundMaxVelocity: 15
-  jumpIntensity: 12
+  sensitivity: 2
+  nonSprintSpeed: 1
+  sprintSpeed: 1.5
 --- !u!114 &8923843087483422746
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1510,8 +1509,8 @@ MonoBehaviour:
   itemHolder: {fileID: 7472229314239848224}
   futureSeer: {fileID: 4961458107837619791}
   cameraBob: {fileID: 5001831470480072933}
-  futureShader: {fileID: 6833996545267069720}
   interactionAudio: {fileID: 2985409494986753327}
+  dialogueManager: {fileID: 0}
 --- !u!114 &4961458107837619791
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1526,7 +1525,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   presentTimeLine: {fileID: 0}
   theFuture: {fileID: 0}
-  watch: {fileID: 7754216125492438131}
+  watch: {fileID: 7754216126538770214}
+  introText: {fileID: 0}
+  transitionSeconds: 1
+  futureAudio:
+    audioMixer: {fileID: 24100000, guid: b780773e875cfd145af240b5b30ff5de, type: 2}
+  futureShader: {fileID: 6833996545267069720}
   _timeVisionEnabled: 0
 --- !u!82 &2985409494986753327
 AudioSource:
@@ -1537,7 +1541,7 @@ AudioSource:
   m_GameObject: {fileID: 8581246045155444791}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 24300002, guid: b780773e875cfd145af240b5b30ff5de, type: 2}
   m_audioClip: {fileID: 8300000, guid: 09a23d5766e3bcf47a6078fd79e7d12d, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 1
@@ -1729,9 +1733,6 @@ MonoBehaviour:
   volume: {fileID: 2567422800216417720}
   cam: {fileID: 8923843087717536974}
   isEffectEnabled: 0
-  currentVolumeWeight: 0
-  currentShaderProgress: 0
-  currentCameraFOV: 0
 --- !u!114 &5001831470480072933
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -4404,7 +4404,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -8952,7 +8952,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -9565,7 +9565,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -9655,7 +9655,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -9849,7 +9849,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -10423,7 +10423,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -4404,7 +4404,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -8952,7 +8952,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -9565,7 +9565,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -9655,7 +9655,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -9849,7 +9849,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name
@@ -10423,7 +10423,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1935243104735377512, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1935243104735377513, guid: f3d88311d902cd742897930f93e4cc77, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -6200,14 +6200,6 @@ PrefabInstance:
       propertyPath: _isInFront
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2985409494986753327, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-      propertyPath: OutputAudioMixerGroup
-      value: 
-      objectReference: {fileID: 24300002, guid: b780773e875cfd145af240b5b30ff5de, type: 2}
-    - target: {fileID: 4961458107837619791, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-      propertyPath: watch
-      value: 
-      objectReference: {fileID: 2001101875}
     - target: {fileID: 4961458107837619791, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
       propertyPath: introText
       value: 
@@ -6228,10 +6220,6 @@ PrefabInstance:
       propertyPath: presentTimeLine
       value: 
       objectReference: {fileID: 528732911}
-    - target: {fileID: 4961458107837619791, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-      propertyPath: futureAudio.audioMixer
-      value: 
-      objectReference: {fileID: 24100000, guid: b780773e875cfd145af240b5b30ff5de, type: 2}
     - target: {fileID: 7472229314239848224, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
       propertyPath: holderCollider
       value: 
@@ -6257,24 +6245,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1035605001}
     - target: {fileID: 8923843087483422747, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-      propertyPath: sensitivity
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8923843087483422747, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-      propertyPath: sprintSpeed
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8923843087483422747, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
       propertyPath: jumpIntensity
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8923843087483422747, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
       propertyPath: groundMaxVelocity
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8923843087483422747, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-      propertyPath: _groundLayer.m_Bits
-      value: 512
       objectReference: {fileID: 0}
     - target: {fileID: 8923843087717536974, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
       propertyPath: m_CullingMask.m_Bits
@@ -10909,17 +10885,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 7b4bd31b17a40784f8fd461b81081f18, type: 3}
   m_PrefabInstance: {fileID: 6173076941165908541}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2001101875 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7754216126538770214, guid: f46053260d8a7284fb177e351e1ff5cd, type: 3}
-  m_PrefabInstance: {fileID: 1026043323}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 663ffd7d62d9a714da52e6b535e44f1a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2041549122
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraShader.cs
+++ b/Assets/Scripts/CameraShader.cs
@@ -6,97 +6,91 @@ using MyBox;
 
 public class CameraShader : MonoBehaviour {
 
-    [SerializeField] [MustBeAssigned] private PostProcessVolume volume;
-    [SerializeField] [MustBeAssigned] private Camera cam;
+  [SerializeField][MustBeAssigned] private PostProcessVolume volume;
+  [SerializeField][MustBeAssigned] private Camera cam;
 
-    [SerializeField] [ReadOnly] private bool isEffectEnabled = false;
-    private float initialFOV;
-    private float deltaFOV = 4;
-    private float finalFOV;
-    private Coroutine currentShaderCoroutine;
-    private Coroutine currentFOVCoroutine;
-    private Coroutine currentVolumeCoroutine;
+  [SerializeField][ReadOnly] private bool isEffectEnabled = false;
+  private float initialFOV;
+  private float deltaFOV = 4;
+  private float finalFOV;
+  private Coroutine currentShaderCoroutine;
+  private Coroutine currentFOVCoroutine;
+  private Coroutine currentVolumeCoroutine;
 
-    void Start() {
-        initialFOV = cam.fieldOfView;
-        finalFOV = initialFOV + deltaFOV;
+  void Start() {
+    initialFOV = cam.fieldOfView;
+    finalFOV = initialFOV + deltaFOV;
+  }
+
+  void OnApplicationQuit() {
+    // This has to be here because of a Unity bug or else the propery value will not go back to default
+    Shader.SetGlobalFloat("_Progress", 0);
+  }
+
+  public void SetEffectEnabled(bool enabled, float transitionTime) {
+    if (isEffectEnabled == enabled) {
+      return;
     }
 
-    void OnApplicationQuit() {
-        // This has to be here because of a Unity bug or else the propery value will not go back to default
-        Shader.SetGlobalFloat("_Progress", 0);
+    if (currentShaderCoroutine != null) StopCoroutine(currentShaderCoroutine);
+    if (currentVolumeCoroutine != null) StopCoroutine(currentShaderCoroutine);
+    if (currentFOVCoroutine != null) StopCoroutine(currentShaderCoroutine);
+
+    OnSetEffectActive(enabled, transitionTime);
+
+    isEffectEnabled = enabled;
+  }
+
+  private void OnSetEffectActive(bool active, float transitionTime) {
+    float end = active ? 1f : 0f;
+    float fovEnd = active ? finalFOV : initialFOV;
+    currentShaderCoroutine = StartCoroutine(TransitionShader(end, transitionTime));
+    currentVolumeCoroutine = StartCoroutine(TransitionVolume(end, transitionTime * 0.5f));
+    currentFOVCoroutine = StartCoroutine(TransitionFOV(fovEnd, transitionTime * 0.1875f));
+  }
+
+  IEnumerator TransitionShader(float end, float duration) {
+    float elapsed_time = 0;
+    float currentProgress = Shader.GetGlobalFloat("_Progress");
+
+    while (elapsed_time <= duration) {
+      Shader.SetGlobalFloat("_Progress", Mathf.Lerp(currentProgress, end, elapsed_time / duration));
+
+      yield return null; //Waits/skips one frame
+
+      elapsed_time += Time.deltaTime;
     }
 
-    public void onEffectActivate() {
-        currentShaderCoroutine = StartCoroutine(TransitionShader(1, 0.8f));
-        currentVolumeCoroutine = StartCoroutine(TransitionVolume(1, 0.4f));
-        currentFOVCoroutine = StartCoroutine(TransitionFOV(finalFOV, 0.15f));
+    Shader.SetGlobalFloat("_Progress", end);
+  }
+
+  IEnumerator TransitionFOV(float end, float duration) {
+    float elapsed_time = 0;
+    float currentProgress = cam.fieldOfView;
+
+    while (elapsed_time <= duration) {
+      cam.fieldOfView = Mathf.Lerp(currentProgress, end, elapsed_time / duration);
+
+      yield return null; //Waits/skips one frame
+
+      elapsed_time += Time.deltaTime;
     }
 
-    public void onEffectDeactivate() {
-        currentShaderCoroutine = StartCoroutine(TransitionShader(0, 0.8f));
-        currentVolumeCoroutine = StartCoroutine(TransitionVolume(0, 0.4f));
-        currentFOVCoroutine = StartCoroutine(TransitionFOV(initialFOV, 0.15f));
-    }
-    IEnumerator TransitionShader(float end, float duration) {
-        float elapsed_time = 0;
-        float currentProgress = Shader.GetGlobalFloat("_Progress");
+    cam.fieldOfView = end;
+  }
 
-        while (elapsed_time <= duration)
-        {
-            Shader.SetGlobalFloat("_Progress", Mathf.Lerp(currentProgress, end, elapsed_time / duration));
+  IEnumerator TransitionVolume(float end, float duration) {
+    float elapsed_time = 0;
+    float currentProgress = volume.weight;
 
-            yield return null; //Waits/skips one frame
+    while (elapsed_time <= duration) {
+      volume.weight = Mathf.Lerp(currentProgress, end, elapsed_time / duration);
 
-            elapsed_time += Time.deltaTime;
-        }
+      yield return null; //Waits/skips one frame
 
-        Shader.SetGlobalFloat("_Progress", end);
+      elapsed_time += Time.deltaTime;
     }
 
-    IEnumerator TransitionFOV(float end, float duration) {
-        float elapsed_time = 0;
-        float currentProgress = cam.fieldOfView;
-
-        while (elapsed_time <= duration)
-        {
-            cam.fieldOfView = Mathf.Lerp(currentProgress, end, elapsed_time / duration);
-
-            yield return null; //Waits/skips one frame
-
-            elapsed_time += Time.deltaTime;
-        }
-
-        cam.fieldOfView = end;
-    }
-
-    IEnumerator TransitionVolume(float end, float duration) {
-        float elapsed_time = 0;
-        float currentProgress = volume.weight;
-
-        while (elapsed_time <= duration) {
-            volume.weight = Mathf.Lerp(currentProgress, end, elapsed_time / duration);
-
-            yield return null; //Waits/skips one frame
-
-            elapsed_time += Time.deltaTime;
-        }
-
-        volume.weight = end;
-    }
-
-    public void ToggleShader() {
-        if (currentShaderCoroutine != null) StopCoroutine(currentShaderCoroutine);
-        if (currentVolumeCoroutine != null) StopCoroutine(currentShaderCoroutine);
-        if (currentFOVCoroutine != null) StopCoroutine(currentShaderCoroutine);
-
-        if (!isEffectEnabled) {
-            isEffectEnabled = true;
-            onEffectActivate();
-        }
-        else {
-            isEffectEnabled = false;
-            onEffectDeactivate();
-        }
-    }
+    volume.weight = end;
+  }
 }

--- a/Assets/Scripts/CameraShader.cs
+++ b/Assets/Scripts/CameraShader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering.PostProcessing;
 using MyBox;
+using System;
 
 public class CameraShader : MonoBehaviour {
 
@@ -27,7 +28,7 @@ public class CameraShader : MonoBehaviour {
     Shader.SetGlobalFloat("_Progress", 0);
   }
 
-  public void SetEffectEnabled(bool enabled, float transitionTime) {
+  public void SetEffectEnabled(bool enabled, float transitionTime, Action onComplete = null) {
     if (isEffectEnabled == enabled) {
       return;
     }
@@ -36,20 +37,20 @@ public class CameraShader : MonoBehaviour {
     if (currentVolumeCoroutine != null) StopCoroutine(currentShaderCoroutine);
     if (currentFOVCoroutine != null) StopCoroutine(currentShaderCoroutine);
 
-    OnSetEffectActive(enabled, transitionTime);
+    OnSetEffectActive(enabled, transitionTime, onComplete);
 
     isEffectEnabled = enabled;
   }
 
-  private void OnSetEffectActive(bool active, float transitionTime) {
+  private void OnSetEffectActive(bool active, float transitionTime, Action onComplete = null) {
     float end = active ? 1f : 0f;
     float fovEnd = active ? finalFOV : initialFOV;
-    currentShaderCoroutine = StartCoroutine(TransitionShader(end, transitionTime));
+    currentShaderCoroutine = StartCoroutine(TransitionShader(end, transitionTime, onComplete));
     currentVolumeCoroutine = StartCoroutine(TransitionVolume(end, transitionTime * 0.5f));
     currentFOVCoroutine = StartCoroutine(TransitionFOV(fovEnd, transitionTime * 0.1875f));
   }
 
-  IEnumerator TransitionShader(float end, float duration) {
+  IEnumerator TransitionShader(float end, float duration, Action onComplete = null) {
     float elapsed_time = 0;
     float currentProgress = Shader.GetGlobalFloat("_Progress");
 
@@ -62,6 +63,8 @@ public class CameraShader : MonoBehaviour {
     }
 
     Shader.SetGlobalFloat("_Progress", end);
+
+    onComplete?.Invoke();
   }
 
   IEnumerator TransitionFOV(float end, float duration) {

--- a/Assets/Scripts/Character/FutureSeer.cs
+++ b/Assets/Scripts/Character/FutureSeer.cs
@@ -6,16 +6,15 @@ using UnityEngine.Audio;
 public class FutureSeer : MonoBehaviour {
 
   [SerializeField] private TimeToggle presentTimeLine;
-
   [SerializeField] private TheFuture theFuture;
 
   [SerializeField] private Watch watch;
 
-  [SerializeField] private float transitionSeconds = 1f;
-
-  [SerializeField] private FutureAudio futureAudio;
-
   [SerializeField] private IntroText introText;
+
+  [SerializeField] private float transitionSeconds = 1f;
+  [SerializeField] private FutureAudio futureAudio;
+  [SerializeField] private CameraShader futureShader;
 
   [SerializeField] private bool _timeVisionEnabled = false;
 
@@ -32,6 +31,7 @@ public class FutureSeer : MonoBehaviour {
     theFuture.SetEnabled(_timeVisionEnabled);
     watch.toggleFutureTime(_timeVisionEnabled);
     futureAudio.SetFutureAudio(_timeVisionEnabled, transitionSeconds);
+    futureShader.SetEffectEnabled(_timeVisionEnabled, transitionSeconds);
 
     if (introText) {
       introText.StartGame();

--- a/Assets/Scripts/Character/FutureSeer.cs
+++ b/Assets/Scripts/Character/FutureSeer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -27,11 +28,21 @@ public class FutureSeer : MonoBehaviour {
 
   public void ToggleFutureVision() {
     _timeVisionEnabled = !_timeVisionEnabled;
-    presentTimeLine.SetEnabled(!_timeVisionEnabled);
-    theFuture.SetEnabled(_timeVisionEnabled);
     watch.toggleFutureTime(_timeVisionEnabled);
     futureAudio.SetFutureAudio(_timeVisionEnabled, transitionSeconds);
-    futureShader.SetEffectEnabled(_timeVisionEnabled, transitionSeconds);
+
+    Action disableTimeline;
+    if (_timeVisionEnabled) {
+      theFuture.SetEnabled(_timeVisionEnabled);
+      presentTimeLine.DisableImmediateComponents();
+      disableTimeline = () => presentTimeLine.SetEnabled(!_timeVisionEnabled);
+    } else {
+      presentTimeLine.SetEnabled(!_timeVisionEnabled);
+      theFuture.DisableImmediateComponents();
+      disableTimeline = () => theFuture.SetEnabled(_timeVisionEnabled);
+    }
+
+    futureShader.SetEffectEnabled(_timeVisionEnabled, transitionSeconds, disableTimeline);
 
     if (introText) {
       introText.StartGame();

--- a/Assets/Scripts/Character/PlayerInput.cs
+++ b/Assets/Scripts/Character/PlayerInput.cs
@@ -8,7 +8,6 @@ public class PlayerInput : BaseInput {
 
   [SerializeField] private FutureSeer futureSeer;
   [SerializeField] private CameraBob cameraBob;
-  [SerializeField] private CameraShader futureShader;
   [SerializeField] private AudioSource interactionAudio;
   [SerializeField] private DialogueManager dialogueManager;
 
@@ -102,7 +101,6 @@ public class PlayerInput : BaseInput {
 
   private void OnToggleFutureVision() {
     futureSeer.ToggleFutureVision();
-    futureShader.ToggleShader();
     if (futureSeer.TimeVisionEnabled && closestOutlinedInteractable != null && closestOutlinedInteractable.shaderChanged) {
       closestOutlinedInteractable.toggleOutlineShader();
     }

--- a/Assets/Scripts/Helpers.cs
+++ b/Assets/Scripts/Helpers.cs
@@ -2,10 +2,16 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using System;
 
 public static class Helpers {
   public static void ResetScene() {
     var activeScene = SceneManager.GetActiveScene();
     SceneManager.LoadScene(activeScene.name);
+  }
+
+  public static IEnumerator InvokeAfterTime(Action action, float timeToWait) {
+    yield return new WaitForSeconds(timeToWait);
+    action.Invoke();
   }
 }

--- a/Assets/Scripts/TheFuture.cs
+++ b/Assets/Scripts/TheFuture.cs
@@ -27,4 +27,10 @@ public class TheFuture : MonoBehaviour {
       timeToggle.SetEnabled(enabled);
     }
   }
+
+  public void DisableImmediateComponents() {
+    foreach (var timeToggle in timeToggles) {
+      timeToggle.DisableImmediateComponents();
+    }
+  }
 }

--- a/Assets/Scripts/TimeToggle.cs
+++ b/Assets/Scripts/TimeToggle.cs
@@ -11,6 +11,8 @@ public class TimeToggle : MonoBehaviour {
 
   [SerializeField][ReadOnly] private bool toggleEnabled = false;
 
+  private Dictionary<Renderer, UnityEngine.Rendering.ShadowCastingMode> rendererToShadowCastingMode = new();
+
   private Renderer[] _cachedRenderers = null;
   private Renderer[] ChildRenderers {
     get {
@@ -51,14 +53,14 @@ public class TimeToggle : MonoBehaviour {
     // Disable children that have faded away
     // TODO: Disable children renderer once they are entirely transparent
     float progress = Shader.GetGlobalFloat("_Progress");
-    
+
     if (progress < 0.02 && !toggleEnabled)
       foreach (var renderer in ChildRenderers)
         renderer.enabled = false;
-    
+
   }
 
-  #if UNITY_EDITOR
+#if UNITY_EDITOR
   [ButtonMethod]
   public void Toggle() {
     _cachedRenderers = GetComponentsInChildren<Renderer>();
@@ -66,7 +68,7 @@ public class TimeToggle : MonoBehaviour {
     _cachedLights = GetComponentsInChildren<Light>();
     SetEnabled(!toggleEnabled);
   }
-  #endif
+#endif
 
   public void SetEnabled(bool enabled) {
     if (gameObject.activeSelf) {
@@ -76,12 +78,30 @@ public class TimeToggle : MonoBehaviour {
       }
       foreach (var renderer in ChildRenderers) {
         renderer.enabled = enabled;
+        if (rendererToShadowCastingMode.TryGetValue(renderer, out var mode)) {
+          renderer.shadowCastingMode = mode;
+        }
       }
       foreach (var light in ChildLights) {
         light.enabled = enabled;
       }
       var toggleEvent = enabled ? timeToggleEnabled : timeToggleDisabled;
       toggleEvent?.Invoke();
+    }
+  }
+
+  public void DisableImmediateComponents() {
+    if (gameObject.activeSelf) {
+      foreach (var renderer in ChildRenderers) {
+        if (renderer is ParticleSystemRenderer) {
+          renderer.enabled = false;
+        }
+        rendererToShadowCastingMode[renderer] = renderer.shadowCastingMode;
+        renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+      }
+      foreach (var light in ChildLights) {
+        light.enabled = false;
+      }
     }
   }
 }

--- a/Assets/Scripts/TimeToggle.cs
+++ b/Assets/Scripts/TimeToggle.cs
@@ -13,27 +13,11 @@ public class TimeToggle : MonoBehaviour {
 
   private Dictionary<Renderer, UnityEngine.Rendering.ShadowCastingMode> rendererToShadowCastingMode = new();
 
-  private ParticleSystem[] _cachedParticleSystems = null;
-  private ParticleSystem[] ChildParticleSystems {
-    get {
-      if (_cachedParticleSystems == null) {
-        _cachedParticleSystems = GetComponentsInChildren<ParticleSystem>();
-      }
-      return _cachedParticleSystems;
-    }
-  }
-
   private Renderer[] _cachedRenderers = null;
   private Renderer[] ChildRenderers {
     get {
       if (_cachedRenderers == null) {
-        List<Renderer> nonParticleRenderers = new();
-        foreach (var renderer in GetComponentsInChildren<Renderer>()) {
-          if (renderer is not ParticleSystemRenderer) {
-            nonParticleRenderers.Add(renderer);
-          }
-        }
-        _cachedRenderers = nonParticleRenderers.ToArray();
+        _cachedRenderers = GetComponentsInChildren<Renderer>();
       }
       return _cachedRenderers;
     }
@@ -92,13 +76,6 @@ public class TimeToggle : MonoBehaviour {
       foreach (var audioSource in ChildAudioSources) {
         audioSource.enabled = enabled;
       }
-      foreach (var particleSystem in ChildParticleSystems) {
-        if (enabled) {
-          particleSystem.Play(); 
-        } else {
-          particleSystem.Stop();
-        }
-      }
       foreach (var renderer in ChildRenderers) {
         renderer.enabled = enabled;
         if (rendererToShadowCastingMode.TryGetValue(renderer, out var mode)) {
@@ -115,10 +92,10 @@ public class TimeToggle : MonoBehaviour {
 
   public void DisableImmediateComponents() {
     if (gameObject.activeSelf) {
-      foreach (var particleSystem in ChildParticleSystems) {
-        particleSystem.Stop();
-      }
       foreach (var renderer in ChildRenderers) {
+        if (renderer is ParticleSystemRenderer a) {
+          renderer.enabled = false;
+        }
         rendererToShadowCastingMode[renderer] = renderer.shadowCastingMode;
         renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
       }

--- a/Assets/Scripts/TimeToggle.cs
+++ b/Assets/Scripts/TimeToggle.cs
@@ -13,11 +13,27 @@ public class TimeToggle : MonoBehaviour {
 
   private Dictionary<Renderer, UnityEngine.Rendering.ShadowCastingMode> rendererToShadowCastingMode = new();
 
+  private ParticleSystem[] _cachedParticleSystems = null;
+  private ParticleSystem[] ChildParticleSystems {
+    get {
+      if (_cachedParticleSystems == null) {
+        _cachedParticleSystems = GetComponentsInChildren<ParticleSystem>();
+      }
+      return _cachedParticleSystems;
+    }
+  }
+
   private Renderer[] _cachedRenderers = null;
   private Renderer[] ChildRenderers {
     get {
       if (_cachedRenderers == null) {
-        _cachedRenderers = GetComponentsInChildren<Renderer>();
+        List<Renderer> nonParticleRenderers = new();
+        foreach (var renderer in GetComponentsInChildren<Renderer>()) {
+          if (renderer is not ParticleSystemRenderer) {
+            nonParticleRenderers.Add(renderer);
+          }
+        }
+        _cachedRenderers = nonParticleRenderers.ToArray();
       }
       return _cachedRenderers;
     }
@@ -76,6 +92,13 @@ public class TimeToggle : MonoBehaviour {
       foreach (var audioSource in ChildAudioSources) {
         audioSource.enabled = enabled;
       }
+      foreach (var particleSystem in ChildParticleSystems) {
+        if (enabled) {
+          particleSystem.Play(); 
+        } else {
+          particleSystem.Stop();
+        }
+      }
       foreach (var renderer in ChildRenderers) {
         renderer.enabled = enabled;
         if (rendererToShadowCastingMode.TryGetValue(renderer, out var mode)) {
@@ -92,10 +115,10 @@ public class TimeToggle : MonoBehaviour {
 
   public void DisableImmediateComponents() {
     if (gameObject.activeSelf) {
+      foreach (var particleSystem in ChildParticleSystems) {
+        particleSystem.Stop();
+      }
       foreach (var renderer in ChildRenderers) {
-        if (renderer is ParticleSystemRenderer) {
-          renderer.enabled = false;
-        }
         rendererToShadowCastingMode[renderer] = renderer.shadowCastingMode;
         renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
       }


### PR DESCRIPTION
## Changes:
- Synchronize all aspects of future transition (audio, shaders, renderers, particle effects) to transition according to one unified timer in `FutureSeer`.

## Comments:
- At first I added something that makes it so particle effects are "stopped" and "played" upon future vision disabling/enabling, but then I wasn't sure if I liked that better or not. So I'm curious to hear what you guys think. Should we A. have particle effects appear/disappear instantly when changing between future and present, or B. have them "play" and "stop" according to their own play/stop logic when changing? Currently A is implemented, but if you want to check out B, check out commit 3edbddf2e19229827d60345bfe94a00451451999 

- This branches off of [`future-audio-mixing`](https://github.com/c-boyle/future-hero/tree/future-audio-mixing) and should be merged after that branch is merged first.

### Screenshots:

Here's a video of option A from above:

https://user-images.githubusercontent.com/62191940/198384423-fd3d027d-ca93-44d5-8b82-eef19575d9ae.mp4

Here's a video of option B from above:

https://user-images.githubusercontent.com/62191940/198384452-88193c64-5cff-4dff-8454-92c02df3d621.mp4



### How to Test:
Open scene and toggle between future and present. Also adjust the timer in `FutureHero`'s `FutureSeer` component to experiment with different transition speeds.

### Impacted Features:
Future vision, camera shader

